### PR TITLE
Now when you click on the speech bubble, visible highlights is also turned on. It is turned off when you close the hypothes.is side-panel.

### DIFF
--- a/src/scripts/directives/hypothesis.js
+++ b/src/scripts/directives/hypothesis.js
@@ -32,16 +32,20 @@ angular.module('Reader')
 
 				annotator.subscribe('annotationEditorShown', function () {
 					setSinglePage(true);
+					window.annotator.setVisibleHighlights(true)
 				});
 				annotator.subscribe('annotationViewerShown', function () {
 					setSinglePage(true);
+					window.annotator.setVisibleHighlights(true)
 				});
 
 				annotator.subscribe('annotationEditorHidden', function () {
 					setSinglePage(false);
+					window.annotator.setVisibleHighlights(false)
 				});
 				annotator.subscribe('annotationViewerHidden', function () {
 					setSinglePage(false);
+					window.annotator.setVisibleHighlights(false)
 				});
 
 				scope.annotator = annotator;


### PR DESCRIPTION
I think this small change makes the interface more intuitive, and separates the reading experience into an annotation mode and a "distraction free reading" mode.
